### PR TITLE
Heap size in MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ require 'jvmargs'
 java_opts = JVMArgs::Args.new("-Xmx512M", "-XX:MaxPermSize=256m"){jmx true} 
 java_opts.heap_size("2048M")
 java_opts.permgen("256M")
+java_opts.newgen("32M")
 # the -Xmx and -Xms arguments are now "-Xmx2048M" and "-Xms2048M"
 # permgen is now "-XX:MaxPermSize=256M"
 ```

--- a/lib/jvmargs/args.rb
+++ b/lib/jvmargs/args.rb
@@ -121,6 +121,12 @@ module JVMArgs
       @args[:unstable]["MaxPermSize"] = JVMArgs::Unstable.new("-XX:MaxPermSize=#{size_ram}")
     end
 
+    def newgen(size)
+      size_ram = JVMArgs::Util.convert_to_m(size)
+      # @args[:unstable]["NewSize"] = JVMArgs::Unstable.new("-XX:NewSize=#{size_ram}")
+      @args[:unstable]["MaxNewSize"] = JVMArgs::Unstable.new("-XX:MaxNewSize=#{size_ram}")
+    end
+
     def add_rule(rule_name, &block)
       @rules.add(rule_name, block)
     end

--- a/spec/jvmargs/args_spec.rb
+++ b/spec/jvmargs/args_spec.rb
@@ -43,6 +43,13 @@ describe JVMArgs::Args do
     args_str = args.to_s
     args_str.should include "-XX:MaxPermSize=#{size}"
   end
+
+  it "set newgen in MB" do
+    size = "32M"
+    args = JVMArgs::Args.new { newgen size }
+    args_str = args.to_s
+    args_str.should include "-XX:MaxNewSize=#{size}"
+  end
   
   it "sets the max heap size to 40% of available RAM if not specified" do
     total_ram = JVMArgs::Util.get_system_ram_m


### PR DESCRIPTION
This example is from the README:

``` ruby
require 'jvmargs'
java_opts = JVMArgs::Args.new("-Xmx512M", "-XX:MaxPermSize=256m"){jmx true} 
java_opts.heap_size("2048M")
java_opts.permgen("256M")
```

The #heap_size method doesn't accept sizes in MBs and #permgen method does not exist. Both fixed in this PR.
