### PR TITLE
Extracting the logic for parsing heap_size to Util.parse_ram_size_to_m

### DIFF
--- a/lib/jvmargs/args.rb
+++ b/lib/jvmargs/args.rb
@@ -96,22 +96,7 @@ module JVMArgs
     end
 
     def heap_size(size)
-      if (size =~ /([0-9]+)%/)
-        percent = $1.to_i * 0.01
-        if percent > 1
-          raise ArgumentError, "heap_size percentage must be less than 100%, you provided #{$1}%"
-        elsif percent < 0.01
-          raise ArgumentError, "heap_size percentage must be between 100% - 1%, you provided #{$1}%"
-        end
-        system_ram = JVMArgs::Util.get_system_ram_m.sub(/M/,'').to_i
-        size_ram = "#{(system_ram * percent).to_i}M"
-      else
-        begin
-          size_ram = JVMArgs::Util.convert_to_m(size)
-        rescue ArgumentError
-           raise ArgumentError, "heap_size percentage must be a percentage or a fixed size in KiloBytes(K), MegaBytes (M), or Gigabytes(G)"
-        end 
-      end
+      size_ram = JVMArgs::Util.parse_ram_size_to_m(size)
       @args[:nonstandard]["Xmx"] = JVMArgs::NonStandard.new("-Xmx#{size_ram}")
       @args[:nonstandard]["Xms"] = JVMArgs::NonStandard.new("-Xms#{size_ram}")
     end

--- a/lib/jvmargs/util.rb
+++ b/lib/jvmargs/util.rb
@@ -39,5 +39,25 @@ module JVMArgs
       [$1.to_i, $2.upcase]
     end
     
+    # Accepts a 'size' value such as 70% or 5G and converts this to
+    # the size in M.
+    def self.parse_ram_size_to_m(size)
+      if (size =~ /([0-9]+)%/)
+        percent = $1.to_i * 0.01
+        if percent > 1
+          raise ArgumentError, "heap_size percentage must be less than 100%, you provided #{$1}%"
+        elsif percent < 0.01
+          raise ArgumentError, "heap_size percentage must be between 100% - 1%, you provided #{$1}%"
+        end
+        system_ram = JVMArgs::Util.get_system_ram_m.sub(/M/,'').to_i
+        size_ram = "#{(system_ram * percent).to_i}M"
+      else
+        begin
+          size_ram = JVMArgs::Util.convert_to_m(size)
+        rescue ArgumentError
+           raise ArgumentError, "heap_size percentage must be a percentage or a fixed size in KiloBytes(K), MegaBytes (M), or Gigabytes(G)"
+        end 
+      end      
+    end
   end
 end

--- a/spec/jvmargs/util_spec.rb
+++ b/spec/jvmargs/util_spec.rb
@@ -2,7 +2,7 @@ require 'jvmargs'
 require 'spec_helper'
 
 describe JVMArgs::Util do
-
+  
   it "returns system ram in megabytes" do
     require 'ohai'
     ohai = Ohai::System.new
@@ -24,4 +24,13 @@ describe JVMArgs::Util do
     JVMArgs::Util.convert_to_m("78G").should == "79872M"
   end
   
+  describe "parse_ram_size_to_m" do
+    it "parses memory sizes" do
+      JVMArgs::Util.parse_ram_size_to_m("73m").should == "73M"
+      JVMArgs::Util.parse_ram_size_to_m("1G").should == "1024M"
+    end
+    it "parses percentage" do
+      JVMArgs::Util.parse_ram_size_to_m("100%").should == JVMArgs::Util.get_system_ram_m
+    end
+  end
 end


### PR DESCRIPTION
This is to allow future (and external) reuse of this logic. The exact
reuse I have in mind is implementing a method for -XX:MaxDirectMemorySize.
