### PR TITLE
allow options such as -Xloggc:file/path and -Xdock:name="thing" to be used

### DIFF
--- a/lib/jvmargs/nonstandard.rb
+++ b/lib/jvmargs/nonstandard.rb
@@ -4,10 +4,10 @@ module JVMArgs
     
     def initialize(arg)
       stripped = arg.sub(/^-/, '')
-      stripped =~ /(X[a-z]+)([0-9]+[a-zA-Z])?/
+      stripped =~ /(X[a-z]+:?)([0-9]+[a-zA-Z])?/
       if $2.nil?
-        @key = stripped # ignore the $1 as could be a -Xthing:that type
-        @value = true
+        @key = $1 
+        @value = stripped[@key.length..-1] # could be an empty string
       else
         @key = $1
         @value = JVMArgs::Util.convert_to_m($2)
@@ -19,11 +19,7 @@ module JVMArgs
     end
     
     def to_s
-      if @value == true
-        "-#{@key}"
-      else
-        "-#{@key}#{@value}"
-      end
+      "-#{@key}#{@value}"
     end
   end
 end

--- a/spec/jvmargs/nonstandard_spec.rb
+++ b/spec/jvmargs/nonstandard_spec.rb
@@ -40,4 +40,10 @@ describe JVMArgs::NonStandard do
     arg = JVMArgs::NonStandard.new('-Xloggc:/var/log/gc.log')    
     arg.to_s.should == '-Xloggc:/var/log/gc.log'
   end
+  
+  it "parameterised arg should seperate on :" do
+    arg = JVMArgs::NonStandard.new('-Xshare:auto')    
+    arg.key.should == 'Xshare:'
+  end
+  
 end


### PR DESCRIPTION
Previous implementation stripped the -Xloggc:value down to -Xloggc which
is an invalid option.
