### PR TITLE
work with Ohai 7 and 6

### DIFF
--- a/lib/jvmargs/util.rb
+++ b/lib/jvmargs/util.rb
@@ -8,7 +8,11 @@ module JVMArgs
       else
         require 'ohai'
         ohai = Ohai::System.new
-        ohai.require_plugin "linux::memory"
+        begin
+          ohai.all_plugins "memory"
+        rescue ArgumentError
+          ohai.require_plugin "linux::memory"
+        end
         total_ram = ohai["memory"]["total"]
       end
       self.convert_to_m(total_ram)


### PR DESCRIPTION
Ohai 7 has changed the way the plugin system loads, and then jvmargs explodes with:

```
Ohai::Exceptions::DependencyNotFound
Can not find a plugin for dependency linux::memory
```
